### PR TITLE
Config: Simplify Playwright config and Prompt for cleaner generated code

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,13 +140,13 @@ Current page title is ${await page.evaluate('document.title')}.
 Here is the overview of the site. Format is in html:
 ${await parseSite(page, options)}
 
-Your output should just be the code that is valid for PlayWright page api. When given the option to use a timeout option, use 1s. Except when using page.goto() use 10s. For actions like click, use the force option to click on hidden elements.
+Your output should just be the code that is valid for PlayWright page api.
 
 User: click on show hn link
 Assistant:
 \`\`\`
 const articleByText = 'Show HN';
-await page.getByText(articleByText, { exact: true }).click(articleByText, {force: true, hidden: true});
+await page.getByText(articleByText, { exact: true }).click(articleByText);
 \`\`\`
 `;
   let code = '';

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,7 +11,6 @@ import {defineConfig, devices} from '@playwright/test';
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  testDir: './tests',
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
@@ -35,6 +34,9 @@ export default defineConfig({
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
+    click: {force: true, timeout: 1000, hidden: true},
+    goto: {timeout: 10000},
+
     /* Base URL to use in actions like `await page.goto('/')`. */
     // baseURL: 'http://localhost:3000',
 


### PR DESCRIPTION
The generated code is cleaner when you don't have to specify the Playwright options on each function call.

This instead sets the values in the Playwright config. This means I can also update the prompt to remove the timeouts.